### PR TITLE
Fixed Plugin for 3.0.2

### DIFF
--- a/Select Group Layers.sketchplugin
+++ b/Select Group Layers.sketchplugin
@@ -6,7 +6,7 @@ function is_group(layer) {
 
 function selectChildren(layers) {
   for (var x=0; x < [layers count]; x++){
-    var childLayer = layers[x];
+    var childLayer = layers.array()[x];
     [childLayer select:true byExpandingSelection:true]
   }
 }


### PR DESCRIPTION
As you probably know, Sketch will switch its scripting backend from [JSTalk](http://jstalk.org) to [CocoaScript](https://github.com/ccgus/CocoaScript) in the upcoming version 3.0.2.

As a result of this change, **some plugins will stop working unless you fix them**. Yours is one of them, so I've taken the liberty to fix it. Please take a look at the info we've compiled at https://github.com/sketchplugins/cocoascript-migration/ for more info, and double check your scripts with [the latest beta](http://bohemiancoding.com/sketch/beta/) to make sure they are, indeed, fixed.

Thanks for your attention, and your contribution to the amazing Sketch Plugins community :)
